### PR TITLE
Added support for `http_proxy` environment variables

### DIFF
--- a/lib/aylien_text_api/connection.rb
+++ b/lib/aylien_text_api/connection.rb
@@ -40,7 +40,7 @@ module AylienTextApi
     end
 
     def request!
-      Net::HTTP.start(@uri.host, @uri.port, use_ssl: (@uri.scheme == 'https')) do |http|
+      Net::HTTP.start(@uri.host, @uri.port, :ENV, use_ssl: (@uri.scheme == 'https')) do |http|
         response = http.request(@request)
         
         limit = response["X-RateLimit-Limit"]


### PR DESCRIPTION
Hello,

This minor modification to `Connection#request!` adds native support for environment proxy configuration. See [`Net::HTTP.start`](https://github.com/ruby/ruby/blob/v2_4_0/lib/net/http.rb#L591-L609) for further details.

This works for Ruby version `>= 2.0`; earlier versions do not accept proxy arguments.

Starting with Ruby `2.5`, this behavior becomes implicit (see [this commit](https://github.com/ruby/ruby/commit/67723c1e4673253b2f4a2c7204ccab9d0daaaeb9)) for further details.